### PR TITLE
Tile rendering fixes

### DIFF
--- a/imaginedsf-custom-theme/acf-json/group_598e781e0e78d.json
+++ b/imaginedsf-custom-theme/acf-json/group_598e781e0e78d.json
@@ -320,6 +320,78 @@
             },
             "default_value": "",
             "placeholder": ""
+        },
+        {
+            "key": "field_5d378f4f4a978",
+            "label": "Minimum Tile Zoom",
+            "name": "min_tile_zoom",
+            "type": "number",
+            "instructions": "The minimum zoom level (most zoomed out) that the server will serve tiles for.  Leave this field blank unless the map layer disappears at low (zoomed out) zoom levels.",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_598e78513ac38",
+                        "operator": "==",
+                        "value": "wms_png"
+                    }
+                ],
+                [
+                    {
+                        "field": "field_598e78513ac38",
+                        "operator": "==",
+                        "value": "tiles"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "min": 0,
+            "max": 20,
+            "step": 1
+        },
+        {
+            "key": "field_5d37901d4a979",
+            "label": "Maximum Tile Zoom",
+            "name": "max_tile_zoom",
+            "type": "number",
+            "instructions": "The maximum zoom level (most zoomed in) that the server will serve tiles for.  Leave this field blank unless the map layer disappears at high (zoomed in) zoom levels.",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_598e78513ac38",
+                        "operator": "==",
+                        "value": "wms_png"
+                    }
+                ],
+                [
+                    {
+                        "field": "field_598e78513ac38",
+                        "operator": "==",
+                        "value": "tiles"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "min": 0,
+            "max": 20,
+            "step": 1
         }
     ],
     "location": [
@@ -355,5 +427,5 @@
     ],
     "active": 1,
     "description": "",
-    "modified": 1563834894
+    "modified": 1563923264
 }

--- a/static-src/scripts/maps/components/leaflet-components.js
+++ b/static-src/scripts/maps/components/leaflet-components.js
@@ -67,8 +67,12 @@ export const getWMSLayer = (layer, layerOpacity) => {
         layer.wms_base_url,
         {
             transparent: true,
+            tiled: true,
+            detectRetina: true,
             format: 'image/png',
             layers: layer.wms_layers,
+            minNativeZoom: layer.wms_min_zoom ? parseInt(layer.wms_min_zoom) : undefined,
+            maxNativeZoom: layer.wms_max_zoom ? parseInt(layer.wms_max_zoom) : undefined,
             opacity: layerOpacity,
         },
     )
@@ -152,6 +156,12 @@ export const getStyleFn = layerOpacity => feature => ({
 export const getTileLayer = (layer, layerOpacity) => {
     return new L.tileLayer(
         layer.tile_url,
-        { opacity: layerOpacity },
+        {
+            opacity: layerOpacity,
+            detectRetina: true,
+            minNativeZoom: layer.min_tile_zoom ? parseInt(layer.min_tile_zoom) : undefined,
+            maxNativeZoom: layer.max_tile_zoom ? parseInt(layer.max_tile_zoom) : undefined,
+
+        },
     )
 }


### PR DESCRIPTION
- Set `tiled=true` on WMS requests so params are the same as what EarthWorks sends on its embedded map view.  Some tiles are still discolored, though (#2).
- Set `detectRetina: true` on WMS and Tile layers so Leaflet will request double the tiles on retina devices.  Helps with #3.
- Added fields to WMS and tile layers for specifying a minimum and maximum zoom level that the server will provide.  Updated Leaflet layer init to use these fields if present (closes #3).