### PR TITLE
Various fixes & improvements

### DIFF
--- a/static-src/components/App.js
+++ b/static-src/components/App.js
@@ -179,7 +179,9 @@ const LoadingError = styled.div`
 
 const StyledApp = styled.div`
   width: 100vw;
+  min-width: 57.75em;
   height: 100vh;
+  min-height: 800px;
   font-family: 'Muli', sans-serif;
   font-size: 16px;
 

--- a/static-src/components/LeafletMap/leaflet.js
+++ b/static-src/components/LeafletMap/leaflet.js
@@ -4,10 +4,28 @@
 
 import {
   TileLayer,
+  GridLayer,
   GeoJSON,
   CRS,
   Point,
 } from 'leaflet';
+
+
+/*
+* Fixes lines lines between tiles (https://github.com/Leaflet/Leaflet/issues/3575#issuecomment-543138318).
+*/
+
+const originalInitTile = GridLayer.prototype._initTile; // eslint-disable-line no-underscore-dangle
+GridLayer.include({
+  _initTile(tile) { // eslint-disable-line no-underscore-dangle
+    originalInitTile.call(this, tile);
+
+    const tileSize = this.getTileSize();
+
+    tile.style.width = `${tileSize.x + 1}px`; // eslint-disable-line no-param-reassign
+    tile.style.height = `${tileSize.y + 1}px`; // eslint-disable-line no-param-reassign
+  },
+});
 
 
 /*

--- a/static-src/components/LeafletMap/leaflet.js
+++ b/static-src/components/LeafletMap/leaflet.js
@@ -56,8 +56,8 @@ export const createWmsLayer = (map, index) => new TileLayer.WMS(
     tiled: true,
     format: 'image/png',
     layers: map.wms.layers,
-    minNativeZoom: map.tile_zoom.min_zoom ? +map.tile_zoom.min_zoom : undefined,
-    maxNativeZoom: map.tile_zoom.max_zoom ? +map.tile_zoom.max_zoom : undefined,
+    minNativeZoom: map.tile_zoom.min_tile_zoom ? +map.tile_zoom.min_tile_zoom : undefined,
+    maxNativeZoom: map.tile_zoom.max_tile_zoom ? +map.tile_zoom.max_tile_zoom : undefined,
     zIndex: index,
   },
 );

--- a/static-src/components/LeafletMap/useHashState.js
+++ b/static-src/components/LeafletMap/useHashState.js
@@ -17,11 +17,10 @@ import { latLngBoundsToArrays } from './leaflet';
 function useGetMapStateFromHash() {
   const mapItems = useSelector((state) => state.mapContent.mapItems);
 
-  const removeMissingIds = useCallback((obj) => Object.assign(
+  const applyToMapContent = useCallback((obj, defaultValue) => Object.assign(
     {},
-    ...Object.entries(obj)
-      .filter(([id]) => Object.prototype.hasOwnProperty.call(mapItems, id))
-      .map(([id, v]) => ({ [id]: v })),
+    ...Object.keys(mapItems)
+      .map((id) => ({ [id]: Object.hasOwnProperty.call(obj, id) ? obj[id] : defaultValue })),
   ), [mapItems]);
 
   return useCallback((hash) => {
@@ -30,14 +29,14 @@ function useGetMapStateFromHash() {
       const { enabled, opacity, bounds } = hashObject.mapState;
 
       return {
-        enabled: removeMissingIds(enabled),
-        opacity: removeMissingIds(opacity),
+        enabled: applyToMapContent(enabled, false),
+        opacity: applyToMapContent(opacity, 1),
         bounds: new LatLngBounds(bounds),
       };
     } catch (e) {
       return null;
     }
-  }, [removeMissingIds]);
+  }, [applyToMapContent]);
 }
 
 

--- a/static-src/components/LeafletMap/useMapState.js
+++ b/static-src/components/LeafletMap/useMapState.js
@@ -49,6 +49,7 @@ export default function useMapState(leafletLayers, visibleMapAreaProxy) {
     if (!currentBounds.equals(bounds)) {
       dispatch(setBounds(currentBounds, map.getCenter(), map.getZoom()));
       dispatch(updateView(map.getCenter(), map.getZoom()));
+      window.ZOOM_LEVEL = map.getZoom();
     }
   }, [dispatch, visibleMapAreaProxy, bounds]);
 

--- a/static-src/components/MapListItem.js
+++ b/static-src/components/MapListItem.js
@@ -2,73 +2,19 @@
 * Imports
 */
 
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-import HTMLContent from './HTMLContent';
 import AccentCheckbox from './AccentCheckbox';
 import AccentDisclosureTriangle from './AccentDisclosureTriangle';
+import useHoverDescriptionOverlay from './useHoverDescriptionOverlay';
 import { setEnabled, setOpacity } from '../state/actions';
 import {
   MAP_GROUP_POST_TYPE,
   GEOJSON_SOURCE_TYPE,
 } from '../constants';
-
-
-/*
-* Custom hook that handles listening for hovers and determining whether
-* the overlay should be visible or not.
-*/
-
-const HOVER_SHOW_DELAY = 1000;
-const HOVER_HIDE_DELAY = 500;
-const useHoverDescriptionOverlay = () => {
-  const [showOverlayAt, setShowOverlayAt] = useState(null);
-  const listItemRef = useRef();
-  const hoverTimeoutId = useRef(null);
-
-  //  Determines where the overlay should be positioned.
-  const getOverlayPosition = () => {
-    const {
-      left: listItemLeft,
-      top: listItemTop,
-      right: listItemRight,
-      bottom: listItemBottom,
-    } = listItemRef.current.getBoundingClientRect();
-
-    //  Determine which quadrant of the screen it's closest to.
-    const listItemOnLeftHalf = (listItemLeft + listItemRight) / 2 < window.innerWidth / 2;
-    const listItemOnTopHalf = (listItemTop + listItemBottom) / 2 < window.innerHeight / 2;
-
-    //  Set overlay position accordingly
-    return {
-      left: listItemOnLeftHalf ? listItemRight : null,
-      top: listItemOnTopHalf ? listItemTop : null,
-      right: listItemOnLeftHalf ? null : window.innerWidth - listItemLeft,
-      bottom: listItemOnTopHalf ? null : window.innerHeight - listItemBottom,
-    };
-  };
-
-  //  On mouseenter, show the overlay after 1 second.
-  const onMouseEnter = () => {
-    clearTimeout(hoverTimeoutId.current);
-    hoverTimeoutId.current = setTimeout(() => {
-      setShowOverlayAt(getOverlayPosition());
-    }, HOVER_SHOW_DELAY);
-  };
-
-  //  On mouseout, hide the overlay after 1 second.
-  const onMouseLeave = () => {
-    clearTimeout(hoverTimeoutId.current);
-    hoverTimeoutId.current = setTimeout(() => {
-      setShowOverlayAt(null);
-    }, HOVER_HIDE_DELAY);
-  };
-
-  return [showOverlayAt, { onMouseEnter, onMouseLeave, ref: listItemRef }];
-};
 
 
 /*
@@ -82,17 +28,9 @@ export default function MapListItem({ id, showYear }) {
     post_type: postType,
     post_title: title,
     source_type: sourceType,
-    metadata: {
-      year,
-      description,
-      recommended_basemap: recommendedBasemapId,
-    },
+    metadata: { year },
     children,
   } = useSelector((state) => state.mapContent.mapItems[id]);
-
-  const recommendedBasemap = useSelector(
-    (state) => (recommendedBasemapId ? state.mapContent.mapItems[recommendedBasemapId] : null),
-  );
 
   const dispatch = useDispatch();
   const handleEnabledUpdate = useCallback(
@@ -105,7 +43,7 @@ export default function MapListItem({ id, showYear }) {
     [dispatch, id],
   );
 
-  const [showOverlayAt, overlayListeners] = useHoverDescriptionOverlay();
+  const [overlayListItemProps, overlayElement] = useHoverDescriptionOverlay(id);
 
   const isGroup = postType === MAP_GROUP_POST_TYPE;
   const isRaster = !isGroup && sourceType !== GEOJSON_SOURCE_TYPE;
@@ -113,7 +51,7 @@ export default function MapListItem({ id, showYear }) {
   return (
     <>
 
-      <StyledMapListItem {...overlayListeners}> {/* eslint-disable-line */}
+      <StyledMapListItem {...overlayListItemProps}> {/* eslint-disable-line */}
 
         <StyledEnabled>
           { isGroup ? (
@@ -157,23 +95,7 @@ export default function MapListItem({ id, showYear }) {
           />
         ) : null }
 
-        { showOverlayAt ? (
-          <StyledHoverOverlay style={showOverlayAt}>
-            { description ? (
-              <StyledOverlayDescription content={description}>
-                <StyledOverlayTitle>{ title }</StyledOverlayTitle>
-              </StyledOverlayDescription>
-            ) : null }
-            { recommendedBasemap ? (
-              <StyledRecommendedBasemap>
-                Recommended Basemap:
-                <StyledStrong>
-                  { recommendedBasemap.post_title }
-                </StyledStrong>
-              </StyledRecommendedBasemap>
-            ) : null }
-          </StyledHoverOverlay>
-        ) : null }
+        { overlayElement }
 
       </StyledMapListItem>
 
@@ -237,44 +159,6 @@ const StyledTitle = styled.a`
     color: ${({ theme, isEnabled }) => (isEnabled ? theme.colors.brightAccent : '#444')};
     opacity: 0.75;
   }
-`;
-
-const StyledHoverOverlay = styled.div`
-  position: fixed;
-  display: flex;
-  flex-direction: column;
-  width: 25em;
-  margin: 0 1em;
-  overflow: hidden;
-  color: #444;
-  background-color: ${({ theme }) => theme.colors.panelBackground};
-  border-radius: ${({ theme }) => theme.radii.standard};
-  box-shadow: ${({ theme }) => theme.shadows.Panel};
-`;
-
-const StyledOverlayTitle = styled.div`
-  margin-top: 0;
-  font-size: 1em;
-  font-weight: bold;
-`;
-
-const StyledOverlayDescription = styled(HTMLContent)`
-  max-height: 25em;
-  padding: 1em;
-  overflow-y: scroll;
-`;
-
-const StyledRecommendedBasemap = styled.div`
-  padding: 0.75em 1em;
-  font-size: 0.85em;
-  text-align: center;
-  background-color: ${({ theme }) => theme.colors.panelBackground};
-  box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
-`;
-
-const StyledStrong = styled.strong`
-  margin-left: 0.5em;
-  color: ${({ theme }) => theme.colors.brightAccent};
 `;
 
 const StyledRange = styled.input`

--- a/static-src/components/MiniMap.js
+++ b/static-src/components/MiniMap.js
@@ -145,7 +145,5 @@ const StyledRectangle = styled.div`
   right: ${({ rectangleRight }) => rectangleRight}px;
   bottom: ${({ rectangleBottom }) => rectangleBottom}px;
   left: ${({ rectangleLeft }) => rectangleLeft}px;
-  background-color: ${({ rectangleAccent, theme }) => (rectangleAccent ? theme.colors.brightAccent25 : theme.colors.darkGrey25)};
-  border: 1.5px solid ${({ rectangleAccent, theme }) => (rectangleAccent ? theme.colors.brightAccent : theme.colors.darkGrey)};
-  border-radius: 2px;
+  background-color: ${({ rectangleAccent, theme }) => (rectangleAccent ? theme.colors.brightAccent25 : theme.colors.miniMapGrey)};
 `;

--- a/static-src/components/useHoverDescriptionOverlay.js
+++ b/static-src/components/useHoverDescriptionOverlay.js
@@ -1,0 +1,127 @@
+import React, { useRef, useState, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import styled from 'styled-components';
+
+import HTMLContent from './HTMLContent';
+
+
+/*
+* Custom hook that handles listening for hovers and determining whether
+* the overlay should be visible or not.
+*/
+
+const HOVER_SHOW_DELAY = 1000;
+const HOVER_HIDE_DELAY = 500;
+export default function useHoverDescriptionOverlay(id) {
+  const [showOverlayAt, setShowOverlayAt] = useState(null);
+  const listItemRef = useRef();
+  const hoverTimeoutId = useRef(null);
+  const {
+    post_title: title,
+    metadata: {
+      description,
+      recommended_basemap: recommendedBasemapId,
+    },
+  } = useSelector((state) => state.mapContent.mapItems[id]);
+
+  const recommendedBasemap = useSelector(
+    (state) => (recommendedBasemapId ? state.mapContent.mapItems[recommendedBasemapId] : null),
+  );
+
+  //  Determines where the overlay should be positioned.
+  const getOverlayPosition = () => {
+    const {
+      left: listItemLeft,
+      top: listItemTop,
+      right: listItemRight,
+      bottom: listItemBottom,
+    } = listItemRef.current.getBoundingClientRect();
+
+    //  Determine which quadrant of the screen it's closest to.
+    const listItemOnLeftHalf = (listItemLeft + listItemRight) / 2 < window.innerWidth / 2;
+    const listItemOnTopHalf = (listItemTop + listItemBottom) / 2 < window.innerHeight / 2;
+
+    //  Set overlay position accordingly
+    return {
+      left: listItemOnLeftHalf ? listItemRight : null,
+      top: listItemOnTopHalf ? listItemTop : null,
+      right: listItemOnLeftHalf ? null : window.innerWidth - listItemLeft,
+      bottom: listItemOnTopHalf ? null : window.innerHeight - listItemBottom,
+    };
+  };
+
+  //  On mouseenter, show the overlay after 1 second.
+  const onMouseEnter = () => {
+    clearTimeout(hoverTimeoutId.current);
+    hoverTimeoutId.current = setTimeout(() => {
+      setShowOverlayAt(getOverlayPosition());
+    }, HOVER_SHOW_DELAY);
+  };
+
+  //  On mouseout, hide the overlay after 1 second.
+  const onMouseLeave = () => {
+    clearTimeout(hoverTimeoutId.current);
+    hoverTimeoutId.current = setTimeout(() => {
+      setShowOverlayAt(null);
+    }, HOVER_HIDE_DELAY);
+  };
+
+  //  Renderable element for the overlay.
+  const overlayElement = useMemo(() => (showOverlayAt ? (
+    <StyledHoverOverlay style={showOverlayAt}>
+      { description ? (
+        <StyledOverlayDescription content={description}>
+          <StyledOverlayTitle>{ title }</StyledOverlayTitle>
+        </StyledOverlayDescription>
+      ) : null }
+      { recommendedBasemap ? (
+        <StyledRecommendedBasemap>
+          Recommended Basemap:
+          <StyledStrong>
+            { recommendedBasemap.post_title }
+          </StyledStrong>
+        </StyledRecommendedBasemap>
+      ) : null }
+    </StyledHoverOverlay>
+  ) : null), [description, recommendedBasemap, showOverlayAt, title]);
+
+  return [{ onMouseEnter, onMouseLeave, ref: listItemRef }, overlayElement];
+}
+
+const StyledHoverOverlay = styled.div`
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  width: 25em;
+  margin: 0 1em;
+  overflow: hidden;
+  color: #444;
+  background-color: ${({ theme }) => theme.colors.panelBackground};
+  border-radius: ${({ theme }) => theme.radii.standard};
+  box-shadow: ${({ theme }) => theme.shadows.Panel};
+`;
+
+const StyledOverlayTitle = styled.div`
+  margin-top: 0;
+  font-size: 1em;
+  font-weight: bold;
+`;
+
+const StyledOverlayDescription = styled(HTMLContent)`
+  max-height: 25em;
+  padding: 1em;
+  overflow-y: scroll;
+`;
+
+const StyledRecommendedBasemap = styled.div`
+  padding: 0.75em 1em;
+  font-size: 0.85em;
+  text-align: center;
+  background-color: ${({ theme }) => theme.colors.panelBackground};
+  box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
+`;
+
+const StyledStrong = styled.strong`
+  margin-left: 0.5em;
+  color: ${({ theme }) => theme.colors.brightAccent};
+`;

--- a/static-src/components/useHoverDescriptionOverlay.js
+++ b/static-src/components/useHoverDescriptionOverlay.js
@@ -1,9 +1,14 @@
-import React, { useRef, useState, useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import React, {
+  useRef,
+  useState,
+  useMemo,
+  useCallback,
+} from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import styled from 'styled-components';
 
 import HTMLContent from './HTMLContent';
-
+import { applyMapState } from '../state/actions';
 
 /*
 * Custom hook that handles listening for hovers and determining whether
@@ -27,6 +32,16 @@ export default function useHoverDescriptionOverlay(id) {
   const recommendedBasemap = useSelector(
     (state) => (recommendedBasemapId ? state.mapContent.mapItems[recommendedBasemapId] : null),
   );
+
+  const basemaps = useSelector((state) => state.mapContent.basemaps);
+
+  const dispatch = useDispatch();
+  const enableOnlyRecommendedBasemap = useCallback(() => dispatch(applyMapState({
+    enabled: Object.assign(
+      {},
+      ...basemaps.map((basemapId) => ({ [basemapId]: basemapId === recommendedBasemapId })),
+    ),
+  })), [basemaps, dispatch, recommendedBasemapId]);
 
   //  Determines where the overlay should be positioned.
   const getOverlayPosition = () => {
@@ -77,13 +92,13 @@ export default function useHoverDescriptionOverlay(id) {
       { recommendedBasemap ? (
         <StyledRecommendedBasemap>
           Recommended Basemap:
-          <StyledStrong>
+          <StyledStrongLink onClick={enableOnlyRecommendedBasemap}>
             { recommendedBasemap.post_title }
-          </StyledStrong>
+          </StyledStrongLink>
         </StyledRecommendedBasemap>
       ) : null }
     </StyledHoverOverlay>
-  ) : null), [description, recommendedBasemap, showOverlayAt, title]);
+  ) : null), [description, enableOnlyRecommendedBasemap, recommendedBasemap, showOverlayAt, title]);
 
   return [{ onMouseEnter, onMouseLeave, ref: listItemRef }, overlayElement];
 }
@@ -121,7 +136,8 @@ const StyledRecommendedBasemap = styled.div`
   box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
 `;
 
-const StyledStrong = styled.strong`
+const StyledStrongLink = styled.strong`
   margin-left: 0.5em;
   color: ${({ theme }) => theme.colors.brightAccent};
+  cursor: pointer;
 `;

--- a/static-src/state/actions.js
+++ b/static-src/state/actions.js
@@ -18,7 +18,8 @@ import {
 export const CONTENT_RECEIVED = 'CONTENT_RECEIVED';
 export const GEOJSON_REQUESTED = 'GEOJSON_REQUESTED';
 export const GEOJSON_RECEIVED = 'GEOJSON_RECEIVED';
-export const SET_MAP_STATE = 'SET_MAP_STATE';
+export const REPLACE_MAP_STATE = 'REPLACE_MAP_STATE';
+export const APPLY_MAP_STATE = 'APPLY_MAP_STATE';
 export const SET_ENABLED = 'SET_ENABLED';
 export const SET_OPACITY = 'SET_OPACITY';
 export const SET_BOUNDS = 'SET_BOUNDS';
@@ -184,7 +185,12 @@ export const geoJsonReceived = (mapId, geoJson) => ({
 });
 
 export const setMapState = (mapState) => ({
-  type: SET_MAP_STATE,
+  type: REPLACE_MAP_STATE,
+  mapState,
+});
+
+export const applyMapState = (mapState) => ({
+  type: APPLY_MAP_STATE,
   mapState,
 });
 

--- a/static-src/state/reducers/mapState.js
+++ b/static-src/state/reducers/mapState.js
@@ -5,7 +5,8 @@
 import { combineReducers } from 'redux';
 
 import {
-  SET_MAP_STATE,
+  REPLACE_MAP_STATE,
+  APPLY_MAP_STATE,
   SET_ENABLED,
   SET_OPACITY,
   SET_BOUNDS,
@@ -20,8 +21,18 @@ import {
 const enabled = (state = {}, action) => {
   switch (action.type) {
     //  Replaces state
-    case SET_MAP_STATE:
+    case REPLACE_MAP_STATE:
       return action.mapState.enabled;
+
+    case APPLY_MAP_STATE:
+      if (action.mapState.enabled) {
+        return {
+          ...state,
+          ...action.mapState.enabled,
+        };
+      }
+
+      return state;
 
     //  Enables/disables single map
     case SET_ENABLED:
@@ -38,8 +49,18 @@ const enabled = (state = {}, action) => {
 const opacity = (state = {}, action) => {
   switch (action.type) {
     //  Replaces state
-    case SET_MAP_STATE:
+    case REPLACE_MAP_STATE:
       return action.mapState.opacity;
+
+    case APPLY_MAP_STATE:
+      if (action.mapState.opacity) {
+        return {
+          ...state,
+          ...action.mapState.opacity,
+        };
+      }
+
+      return state;
 
     //  Enables/disables single map
     case SET_OPACITY:
@@ -56,8 +77,15 @@ const opacity = (state = {}, action) => {
 const bounds = (state = null, action) => {
   switch (action.type) {
     //  Replaces state
-    case SET_MAP_STATE:
+    case REPLACE_MAP_STATE:
       return action.mapState.bounds;
+
+    case APPLY_MAP_STATE:
+      if (action.mapState.bounds) {
+        return action.mapState.bounds;
+      }
+
+      return state;
 
     //  Updates bounds
     case SET_BOUNDS:

--- a/static-src/theme.js
+++ b/static-src/theme.js
@@ -8,12 +8,12 @@ const colors = {
   lightBlack: '#333',
   darkerGrey: '#414042',
   darkGrey: '#58595b',
-  darkGrey25: 'rgba(88, 89, 91, 0.25)',
+  miniMapGrey: 'rgba(0, 0, 0, 0.43)',
   lightGrey: '#cecece',
   lighterGrey: '#d8d8d8',
   panelBackground: '#efefef',
   brightAccent: '#d83a3a',
-  brightAccent25: 'rgba(216, 58, 58, 0.25)',
+  brightAccent25: 'rgba(216, 58, 58, 0.53)',
   darkAccent: '#bf3333',
 };
 


### PR DESCRIPTION
- Adds a minimum width and height to the app so mobile views are very small but look okay.
- Applies patch to fix issue of lines between tiles (closes #79).
- Fixes bug preventing min zoom and max zoom settings from working on WMS layers (closes #81).
- Saves current zoom level to `window.ZOOM_LEVEL` for admin access.
- Re-fixes console error when hash references maps that aren't present (#56).
- Factors hover map description out into its own hook.
- Makes recommended basemap into a link (closes #75).
- Updated minimap style (closes #54).